### PR TITLE
Support React 18 as a peer-dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - "node"
+  - "lts/*"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "use-isomorphic-layout-effect": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
* Adds support for the recently released [React 18](https://reactjs.org/blog/2022/03/29/react-v18.html).
* Switched Travis' node version because Node 18 is currently [reported as failing](https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909).

This new version will then be proposed on `react-textarea-autosize`.