### PR TITLE
Add React 19 to the required peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "use-isomorphic-layout-effect": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "use-isomorphic-layout-effect": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Thanks a lot for this package

I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

```ts
packages/react-playground
└─┬ react-textarea-autosize 8.5.4
  ├── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
  ├─┬ use-composed-ref 1.3.0
  │ └── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
  └─┬ use-latest 1.2.1
    ├── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
    └─┬ use-isomorphic-layout-effect 1.1.2
      └── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
```
